### PR TITLE
Change to new cran checks badge URL

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 [![codecov](https://codecov.io/gh/alastairrushworth/inspectdf/branch/master/graph/badge.svg)](https://codecov.io/gh/alastairrushworth/inspectdf)
 [![CRAN status](https://www.r-pkg.org/badges/version/inspectdf)](https://cran.r-project.org/package=inspectdf)
 [![](https://cranlogs.r-pkg.org/badges/inspectdf)](https://cran.r-project.org/package=inspectdf)
-[![cran checks](https://cranchecks.info/badges/summary/inspectdf)](https://cran.r-project.org/web/checks/check_results_inspectdf.html)  
+[![cran checks](https://badges.cranchecks.info/worst/inspectdf.svg)](https://cran.r-project.org/web/checks/check_results_inspectdf.html)  
 
 Overview
 ---
@@ -59,21 +59,4 @@ Comments? Suggestions? Issues?
 ---  
 
 Any feedback is welcome! Feel free to write a github issue or send me a message on [twitter](https://twitter.com/rushworth_a).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # inspectdf <img src="man/figures/logo.png" align="right" width="120" />
 
 ![build](https://github.com/alastairrushworth/inspectdf/workflows/R-CMD-check/badge.svg)
@@ -7,7 +6,7 @@
 status](https://www.r-pkg.org/badges/version/inspectdf)](https://cran.r-project.org/package=inspectdf)
 [![](https://cranlogs.r-pkg.org/badges/inspectdf)](https://cran.r-project.org/package=inspectdf)
 [![cran
-checks](https://cranchecks.info/badges/summary/inspectdf)](https://cran.r-project.org/web/checks/check_results_inspectdf.html)
+checks](https://badges.cranchecks.info/worst/inspectdf.svg)](https://cran.r-project.org/web/checks/check_results_inspectdf.html)
 
 ## Overview
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -196,7 +196,7 @@
 <li><a href="https://codecov.io/gh/alastairrushworth/inspectdf" class="external-link"><img src="https://codecov.io/gh/alastairrushworth/inspectdf/branch/master/graph/badge.svg" alt="codecov"></a></li>
 <li><a href="https://cran.r-project.org/package=inspectdf" class="external-link"><img src="https://www.r-pkg.org/badges/version/inspectdf" alt="CRAN status"></a></li>
 <li><a href="https://cran.r-project.org/package=inspectdf" class="external-link"><img src="https://cranlogs.r-pkg.org/badges/inspectdf"></a></li>
-<li><a href="https://cran.r-project.org/web/checks/check_results_inspectdf.html" class="external-link"><img src="https://cranchecks.info/badges/summary/inspectdf" alt="cran checks"></a></li>
+<li><a href="https://cran.r-project.org/web/checks/check_results_inspectdf.html" class="external-link"><img src="https://badges.cranchecks.info/worst/inspectdf.svg" alt="cran checks"></a></li>
 </ul>
 </div>
 


### PR DESCRIPTION
Related to #46

Update the URL for the cran checks badge to the new format.

* **README.md**
  - Update the URL for the cran checks badge to the new format.
* **README.Rmd**
  - Update the URL for the cran checks badge to the new format.
* **docs/index.html**
  - Update the URL for the cran checks badge to the new format.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alastairrushworth/inspectdf/issues/46?shareId=f7117ed4-9fea-40fd-ae46-75879243f869).